### PR TITLE
feat: add retry delay to workflow

### DIFF
--- a/convex/labs/actions.ts
+++ b/convex/labs/actions.ts
@@ -18,11 +18,17 @@ export const startGenerationQuestion = internalAction({
 				labId: args.labId,
 			},
 		);
+		const MAX_RETRIES = 60;
+		let retries = 0;
 		try {
 			while (true) {
 				const status = await workflow.status(ctx, workflowId);
 				if (status.type === "inProgress") {
-					continue;
+				if (retries++ >= MAX_RETRIES) {
+				throw new Error("Workflow timed out");
+				}
+				await new Promise((res) => setTimeout(res, 1000));
+				continue;
 				}
 				console.log("Workflow completed with status:", status);
 				break;


### PR DESCRIPTION
## Summary
- avoid busy looping by inserting 1-second delay during workflow status checks
- add max retry limit to prevent hanging indefinitely

## Testing
- `npm test` *(fails: Missing script "test")*
- `bun run typecheck` *(fails: react-router: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6898b95de9988324b786bb76b00524c7